### PR TITLE
feat: gate hero shuffle on Data Saver, not viewport width

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
           preload="none"
           poster="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3Crect width='16' height='9' fill='black'/%3E%3C/svg%3E"
         >
-          <!-- NOTE: Source is injected by JS on desktop only to reduce initial mobile payload. -->
+          <!-- NOTE: Clip sources are set by JS when shuffle runs (skipped if Data Saver or reduced motion). -->
         </video>
         <div class="hero-overlay"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -435,16 +435,20 @@ class SinglePagePortfolio {
     });
   }
 
+  // NOTE: Skip multi-clip hero shuffle when Data Saver is on (Network Information API) or user prefers reduced motion; otherwise shuffle on every viewport size.
+  shouldSkipHeavyVideoShuffle() {
+    const saveDataOn = typeof navigator !== 'undefined' && navigator.connection?.saveData === true;
+    if (saveDataOn) return true;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
   // NOTE: Interactive timeline (process prioritization)
   setupHeroVideoShuffle() {
     const heroVideo = document.querySelector('[data-hero-video-shuffle]');
     if (!heroVideo) return;
-    const skipHeavyHeroVideo =
-      window.matchMedia('(max-width: 767px)').matches ||
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // NOTE: Keep a lightweight static hero on mobile/reduced-motion to improve first-load performance.
-    if (skipHeavyHeroVideo) {
+    // NOTE: Static hero (no clip cycling) when saving data or reduced motion; avoids large downloads in those modes.
+    if (this.shouldSkipHeavyVideoShuffle()) {
       heroVideo.pause();
       heroVideo.removeAttribute('src');
       heroVideo.load();
@@ -554,12 +558,9 @@ class SinglePagePortfolio {
     const isPrototypingOrProduksjonCategory =
       pathname.includes('/category/prototyping/') ||
       pathname.includes('/category/teknisk-tegning/');
-    const skipHeavyCategoryVideo =
-      window.matchMedia('(max-width: 767px)').matches ||
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // NOTE: Disable decorative category hero video on mobile/reduced-motion to cut transfer and CPU usage.
-    if (skipHeavyCategoryVideo) {
+    // NOTE: Same gating as home hero: no shuffle under Data Saver or reduced motion.
+    if (this.shouldSkipHeavyVideoShuffle()) {
       categoryVideo.pause();
       categoryVideo.removeAttribute('src');
       categoryVideo.load();


### PR DESCRIPTION
Run multi-clip shuffle on all screen sizes when saveData is off; skip when Network Information API reports data saver. Keep reduced-motion skip. Update hero video comment in index.html.