### PR TITLE
Fix Search Console redirects and homepage JSON-LD

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,18 @@
 # NOTE: Canonical homepage URL rules and index handling.
 RewriteEngine On
 
+# NOTE: One hop for legacy http://www → canonical https://formaa.no (Search Console / duplicate host cleanup).
+RewriteCond %{HTTP_HOST} ^www\.formaa\.no$ [NC]
+RewriteCond %{HTTPS} !=on
+RewriteRule ^ https://formaa.no%{REQUEST_URI} [L,R=301]
+
 # NOTE: Force HTTPS for all requests before other canonical rules.
 RewriteCond %{HTTPS} !=on
 RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# NOTE: Canonical host is apex formaa.no (strip www on HTTPS after scheme is correct).
+RewriteCond %{HTTP_HOST} ^www\.formaa\.no$ [NC]
+RewriteRule ^ https://formaa.no%{REQUEST_URI} [L,R=301]
 
 # NOTE: Send HSTS header on HTTPS responses to enforce secure transport.
 <IfModule mod_headers.c>
@@ -27,6 +36,10 @@ RewriteRule ^assets/favicon\.svg$ /assets/Favicon-google-search.svg [R=301,L]
 # NOTE: Move legacy flat article/project slugs into section-based URLs.
 RewriteRule ^prosjekt-([a-z0-9-]+)/?$ /prosjekter/$1 [R=301,L]
 RewriteRule ^innsikt-([a-z0-9-]+)/?$ /innsikt/$1 [R=301,L]
+
+# NOTE: Legacy `.html` flat URLs (e.g. Search Console) → same canonical `/prosjekter/{slug}` and `/innsikt/{slug}` before generic `.html` strip.
+RewriteRule ^prosjekt-([a-z0-9-]+)\.html$ /prosjekter/$1 [R=301,L]
+RewriteRule ^innsikt-([a-z0-9-]+)\.html$ /innsikt/$1 [R=301,L]
 
 # NOTE: Heal legacy 404s from Search Console: duplicate Innsikt paths, bad /category/…
 # relatives, renamed produksjon → teknisk-tegning, and non-existent “index” hubs.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Structured data currently used:
 
 ## URL Canonicalization
 
-- `.htaccess` (Apache) canonicalizes HTTP → HTTPS, strips `.html` from URLs, maps `/prosjekter/{slug}` and `/innsikt/{slug}` to the legacy `prosjekt-*.html` / `innsikt-*.html` files, and includes explicit 301s for friendly top-level routes such as `/designstudio-oslo` and `/application-form` (plus Search Console legacy paths: duplicate `/innsikt/innsikt-*`, bad `/category/.../index`, `produksjon` → `teknisk-tegning`, etc.). If you deploy on a host that ignores `.htaccess`, replicate these rules in that platform’s redirect config.
+- `.htaccess` (Apache) canonicalizes HTTP → HTTPS, 301s `www.formaa.no` to apex `https://formaa.no`, strips `.html` from URLs, maps `/prosjekter/{slug}` and `/innsikt/{slug}` to the legacy `prosjekt-*.html` / `innsikt-*.html` files, 301s legacy `prosjekt-*.html` / `innsikt-*.html` to `/prosjekter/{slug}` / `/innsikt/{slug}` (before the generic `.html` strip), and includes explicit 301s for friendly top-level routes such as `/designstudio-oslo` and `/application-form` (plus Search Console legacy paths: duplicate `/innsikt/innsikt-*`, bad `/category/.../index`, `produksjon` → `teknisk-tegning`, etc.). If you deploy on a host that ignores `.htaccess`, replicate these rules in that platform’s redirect config.
 - Homepage: `/index.html` → `/` (301).
 - Public routes are extensionless (for example `/gallery`, `/prosjekter`, `/innsikt`, `/application-form`); legacy flat filenames redirect into those namespaces.
 

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           "Brukerundersøkelser",
           "Validering",
           "3D-visualisering",
-          "Produksjonsforberedelse"
+          "Produksjonsforberedelse",
           "Teknisk design"
         ],
         "hasOfferCatalog": {


### PR DESCRIPTION
- .htaccess: 301 www to apex (http www one hop to https apex; https www to apex)
- .htaccess: 301 prosjekt-*.html and innsikt-*.html to /prosjekter/ and /innsikt/ before generic .html strip
- README: document www and legacy flat .html redirect behaviour
- index.html: add missing comma in ProfessionalService serviceType JSON-LD array